### PR TITLE
Run charm-proof after a successful charm-build

### DIFF
--- a/charmtools/build/__init__.py
+++ b/charmtools/build/__init__.py
@@ -23,6 +23,7 @@ from charmtools.build.fetchers import (
 )
 from charmtools import utils
 from .. import repofinder
+from .. import proof
 
 
 log = logging.getLogger("build")
@@ -673,6 +674,10 @@ def main(args=None):
             build.check_series()
 
         build()
+
+        lint, exit_code = proof.proof(os.getcwd(), False, False)
+        if lint:
+            print("\n".join(lint))
     except (BuildError, FetchError) as e:
         log.error(*e.args)
         raise SystemExit(1)

--- a/charmtools/build/__init__.py
+++ b/charmtools/build/__init__.py
@@ -677,7 +677,14 @@ def main(args=None):
 
         lint, exit_code = proof.proof(os.getcwd(), False, False)
         if lint:
-            print("\n".join(lint))
+            llog = logging.getLogger("proof")
+            for line in lint:
+                if line[0] == "I":
+                    llog.info(line)
+                elif line[0] == "W":
+                    llog.warn(line)
+                elif line[0] == "E":
+                    llog.error(line)
     except (BuildError, FetchError) as e:
         log.error(*e.args)
         raise SystemExit(1)


### PR DESCRIPTION
This addresses issue #171, by running a proof immediately after a successful build
